### PR TITLE
Add developer comments to package code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,76 @@ TypeScript for modern Node.js projects.
 }
 ```
 
-## Usage Example with Async and Await
+## Usage
+
+### Basic Example
 
 ```ts
 import { getPodcast } from 'podson';
 
-const feedUrl = 'Podcast Feed URL';
+const feedUrl = 'https://example.com/podcast/feed.xml';
 
 (async () => {
   const podcast = await getPodcast(feedUrl);
   console.log(podcast.title);
 })();
+```
+
+### Working with Episodes
+
+Episodes are automatically sorted by publication date (newest first):
+
+```ts
+import { getPodcast } from 'podson';
+
+const podcast = await getPodcast('https://example.com/podcast/feed.xml');
+
+// Get the latest episode
+if (podcast.episodes && podcast.episodes.length > 0) {
+  const latest = podcast.episodes[0];
+  console.log(`Latest episode: ${latest.title}`);
+  console.log(`Published: ${latest.published}`);
+  console.log(`Duration: ${latest.duration} seconds`);
+  console.log(`Audio URL: ${latest.enclosure?.url}`);
+}
+
+// List all episodes
+podcast.episodes?.forEach((episode) => {
+  console.log(`- ${episode.title} (${episode.published})`);
+});
+```
+
+### Error Handling
+
+```ts
+import { getPodcast } from 'podson';
+
+try {
+  const podcast = await getPodcast('https://example.com/podcast/feed.xml');
+  console.log(`Successfully fetched: ${podcast.title}`);
+} catch (error) {
+  console.error('Failed to fetch podcast:', error.message);
+  // Possible errors:
+  // - Network timeout (after 10 seconds)
+  // - HTTP errors (404, 500, etc.)
+  // - XML parsing errors
+}
+```
+
+### TypeScript Support
+
+All types are fully documented and exported for use in your projects:
+
+```ts
+import { getPodcast, Podcast, Episode, Enclosure } from 'podson';
+
+// The returned podcast object is fully typed
+const podcast: Podcast = await getPodcast('https://example.com/feed.xml');
+
+// Access properties with full IntelliSense support
+const title: string | undefined = podcast.title;
+const episodes: Episode[] | undefined = podcast.episodes;
+const categories: string[] = podcast.categories; // Always present, may be empty
 ```
 
 ## Building

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
+/**
+ * @packageDocumentation
+ * Podson - A podcast RSS/XML feed parser that converts podcast feeds into clean JSON objects.
+ *
+ * This module provides functionality to fetch and parse podcast RSS feeds, extracting metadata,
+ * episodes, and related information into well-structured TypeScript interfaces.
+ *
+ * @module podson
+ */
+
 import uniq from 'lodash/uniq';
 import sax, { Tag } from 'sax';
 import got from 'got';
 
-import { Podcast, Episode, Owner } from './types';
+import { Podcast, Episode, Owner, Enclosure, Chapter } from './types';
 
 interface ParsingNode {
   name: string;
@@ -225,6 +235,59 @@ function parse(feedXML: string): Promise<Podcast> {
   });
 }
 
+/**
+ * Fetches and parses a podcast RSS/XML feed into a structured JSON object.
+ *
+ * This is the main function of the podson library. It downloads the podcast feed from the
+ * provided URL, parses the XML, and returns a clean, structured Podcast object with all
+ * episodes and metadata.
+ *
+ * @param feedUrl - The URL of the podcast RSS/XML feed to fetch and parse
+ * @returns A Promise that resolves to a Podcast object containing all feed data
+ *
+ * @throws {Error} When the feed cannot be fetched (network error, timeout, HTTP error)
+ * @throws {Error} When the feed XML cannot be parsed (malformed XML)
+ *
+ * @example
+ * Basic usage:
+ * ```typescript
+ * import { getPodcast } from 'podson';
+ *
+ * const podcast = await getPodcast('https://example.com/podcast/feed.xml');
+ * console.log(podcast.title);
+ * console.log(podcast.episodes?.length);
+ * ```
+ *
+ * @example
+ * With error handling:
+ * ```typescript
+ * import { getPodcast } from 'podson';
+ *
+ * try {
+ *   const podcast = await getPodcast('https://example.com/podcast/feed.xml');
+ *
+ *   // Access podcast metadata
+ *   console.log(`Podcast: ${podcast.title}`);
+ *   console.log(`Author: ${podcast.author}`);
+ *   console.log(`Episodes: ${podcast.episodes?.length}`);
+ *
+ *   // Access latest episode
+ *   if (podcast.episodes && podcast.episodes.length > 0) {
+ *     const latestEpisode = podcast.episodes[0]; // Episodes are sorted newest first
+ *     console.log(`Latest: ${latestEpisode.title}`);
+ *     console.log(`Audio: ${latestEpisode.enclosure?.url}`);
+ *   }
+ * } catch (error) {
+ *   console.error('Failed to fetch podcast:', error.message);
+ * }
+ * ```
+ *
+ * @remarks
+ * - Uses HTTP/2 when available for better performance
+ * - Timeout is set to 10 seconds
+ * - Episodes in the returned object are automatically sorted by publication date (newest first)
+ * - All fields in the Podcast object are optional except 'categories' (which defaults to an empty array)
+ */
 export async function getPodcast(feedUrl: string): Promise<Podcast> {
   try {
     const data = await got(feedUrl, {
@@ -248,5 +311,8 @@ export async function getPodcast(feedUrl: string): Promise<Podcast> {
     throw new Error(`Failed to fetch podcast: ${errorMessage}`);
   }
 }
+
+// Re-export types for developer convenience
+export type { Podcast, Episode, Owner, Enclosure, Chapter } from './types';
 
 export default { getPodcast };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,48 +1,107 @@
+/**
+ * Represents a chapter marker within a podcast episode.
+ * Chapters allow listeners to navigate to specific sections of an episode.
+ */
 export interface Chapter {
+  /** Start time of the chapter in seconds from the beginning of the episode */
   start: number;
+  /** Title/name of the chapter */
   title: string;
 }
 
+/**
+ * Represents the media file attachment for a podcast episode.
+ * Contains information about the audio/video file that can be downloaded or streamed.
+ */
 export interface Enclosure {
+  /** Size of the media file in bytes */
   filesize?: number;
+  /** MIME type of the media file (e.g., 'audio/mpeg', 'audio/mp4') */
   type?: string;
+  /** Direct URL to the media file */
   url?: string;
 }
 
+/**
+ * Represents a single podcast episode.
+ * Contains metadata and content information for an individual episode.
+ */
 export interface Episode {
+  /** Globally unique identifier for the episode */
   guid?: string;
+  /** Episode title */
   title?: string;
+  /** Short subtitle or tagline for the episode */
   subtitle?: string;
+  /** Plain text description of the episode */
   description?: string;
+  /** Summary of the episode (may overlap with description) */
   summary?: string;
+  /** Full HTML content/show notes for the episode */
   content?: string;
+  /** URL to the episode's artwork/cover image */
   image?: string;
+  /** Publication date and time of the episode */
   published?: Date;
+  /** Duration of the episode in seconds */
   duration?: number;
+  /** List of categories/tags associated with this episode */
   categories?: string[];
+  /** Media file information (audio/video file to play) */
   enclosure?: Enclosure;
+  /** Chapter markers for navigation within the episode */
   chapters?: Chapter[];
 }
 
+/**
+ * Represents the owner/creator of a podcast.
+ * Contains contact information for the podcast owner.
+ */
 export interface Owner {
+  /** Name of the podcast owner */
   name?: string;
+  /** Contact email address for the podcast owner */
   email?: string;
 }
 
+/**
+ * Represents a complete podcast feed with all its metadata and episodes.
+ * This is the main data structure returned by the getPodcast() function.
+ *
+ * @remarks
+ * - Episodes are automatically sorted by publication date (newest first)
+ * - Categories use '>' as a separator for hierarchical categories (e.g., 'Technology>Podcasting')
+ * - Most fields are optional as not all podcast feeds include all metadata
+ */
 export interface Podcast {
+  /** Podcast title/name */
   title?: string;
+  /** Short subtitle or tagline for the podcast */
   subtitle?: string;
+  /** Brief summary of the podcast */
   summary?: string;
+  /** Detailed description of the podcast */
   description?: string;
+  /** URL to the podcast's website */
   link?: string;
+  /** URL to the podcast's cover artwork */
   image?: string;
+  /** Language code in format 'en-us', 'de-de', etc. */
   language?: string;
+  /** Copyright notice for the podcast */
   copyright?: string;
+  /** Primary author/creator of the podcast */
   author?: string;
+  /** Time-to-live in minutes - suggested update frequency */
   ttl?: number;
+  /** Last update date (derived from most recent episode if not provided in feed) */
   updated?: Date | null;
+  /** Array of podcast categories, sorted alphabetically. Hierarchical categories use '>' separator */
   categories: string[];
+  /** Podcast owner/contact information */
   owner?: Owner;
+  /** Array of episodes, sorted by publication date (newest first) */
   episodes?: Episode[];
+  /** URL of the original RSS/XML feed */
   feed?: string;
 }


### PR DESCRIPTION
- Add JSDoc comments to all exported types (Podcast, Episode, Owner, Enclosure, Chapter)
- Add detailed JSDoc documentation to getPodcast() function with examples
- Export all types from main module for developer convenience
- Enhance README with practical usage examples for common scenarios
- Include error handling examples and TypeScript usage guidance

This improves the developer experience by providing clear documentation, usage examples, and full TypeScript IntelliSense support.