### PR TITLE
Configure tsup for universal package support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,25 @@
   "version": "1.2.0",
   "description": "Reads podcast feeds and converts them into json.",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
   "keywords": [
     "podcast",
     "json",
@@ -20,7 +37,7 @@
   "author": "Thomas Wiegold",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p .",
+    "build": "tsup",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.ts\"",
@@ -45,6 +62,7 @@
     "eslint": "^9.17.0",
     "happy-dom": "^20.0.10",
     "prettier": "^3.4.2",
+    "tsup": "^8.5.1",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.0.13"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,21 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "ESNext",
     "lib": ["ES2020"],
     "outDir": "dist",
     "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "bundler"
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  minify: false,
+  target: 'es2020',
+  outDir: 'dist',
+  // Keep external dependencies external (not bundled)
+  external: ['got', 'sax', 'lodash'],
+  // Preserve modules for better tree-shaking
+  shims: false,
+  // Generate both index.js (CJS) and index.mjs (ESM)
+  outExtension({ format }) {
+    return {
+      js: format === 'cjs' ? '.cjs' : '.mjs',
+    };
+  },
+});


### PR DESCRIPTION
- Add tsup as build tool with ESM and CJS output formats
- Configure dual package exports in package.json with proper module resolution
- Update build script to use tsup instead of tsc
- Generate both .mjs (ESM) and .cjs (CommonJS) files with type declarations
- Add files field and sideEffects: false for better tree-shaking
- Update tsconfig.json with modern compiler options and noEmit flag
- Configure tsup to preserve external dependencies (got, sax, lodash)
- Add source maps and declaration maps for better debugging

This configuration enables the package to be used across all environments including Node.js, browsers, React, React Native, and edge runtimes with proper module resolution for both ESM and CJS consumers.